### PR TITLE
Use goal.displayed_.... for impacts, now calculated in API

### DIFF
--- a/frontend/components/Pages/CommunityPage/CommunityPage.js
+++ b/frontend/components/Pages/CommunityPage/CommunityPage.js
@@ -37,7 +37,7 @@ function GoalsCard({ navigation, goals, community_id }) {
         nameLong: "Individual Actions Completed",
         nameShort: "Actions",
         goal: goals.target_number_of_actions,
-        current: goals.initial_number_of_actions + goals.attained_number_of_actions + goals.organic_attained_number_of_actions
+        current: goals.displayed_number_of_actions
       })
     }
     if (goals.target_number_of_households != 0) {
@@ -45,7 +45,7 @@ function GoalsCard({ navigation, goals, community_id }) {
         nameLong: "Households Taking Action",
         nameShort: "Households",
         goal: goals.target_number_of_households,
-        current: goals.attained_number_of_households + goals.organic_attained_number_of_households
+        current: goals.displayed_number_of_households
       })
     }
     if (goals.target_carbon_footprint_reduction != 0) {
@@ -53,7 +53,7 @@ function GoalsCard({ navigation, goals, community_id }) {
         nameLong: "Carbon Reduction Impact",
         nameShort: "Trees",
         goal: goals.target_carbon_footprint_reduction / 133,
-        current: (goals.initial_carbon_footprint_reduction / 133) + (goals.organic_attained_carbon_footprint_reduction / 133)
+        current: (goals.displayed_carbon_footprint_reduction / 133)
       })
     }
     return goalsList

--- a/frontend/data/communitiesInfo.json
+++ b/frontend/data/communitiesInfo.json
@@ -23,6 +23,9 @@
             "organic_attained_number_of_households": 295,
             "organic_attained_number_of_actions": 1381,
             "organic_attained_carbon_footprint_reduction": 2108429,
+            "displayed_number_of_households": 295,
+            "displayed_number_of_actions": 1381,
+            "displayed_carbon_footprint_reduction": 2108429,
             "target_date": null,
             "more_info": null
         },


### PR DESCRIPTION
For consistency with the web front-end, the community impact numbers (households, actions and carbon) are now calculated in the API using the community admin preferences.